### PR TITLE
Lager første utkast til manuelle obo-token i localhost mot dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 BASE_PATH="/rapportering"
 DP_RAPPORTERING_URL="https://dp-rapportering.intern.dev.nav.no"
 IS_LOCALHOST="true"
+DP_RAPPORTERING_TOKEN=""
 AUTH_PROVIDER="local"
 LOCAL_TOKEN=""
 NAIS_CLUSTER_NAME="dev-gcp"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Sett `USE_MSW="false"` dersom du ikke får det til å kjøre.
 
 ---
 
+## Kjøre mot dev-APIer i localhost
+
+For å kjøre requester mot dp-rapportering må vi ha et token, generert med [wonderwalled-idporten](https://wonderwalled-idporten.intern.dev.nav.no/api/obo?aud=dev-gcp:teamdagpenger:dp-rapportering). Logg på med testid. Hent ut verdien fra `access_token`, rediger `.env` og endre `DP_RAPPORTERING_TOKEN` til det nylig genererte tokenet. Env-variabelen `IS_LOCALHOST="true"` må også være satt.
+
+Dette tokenet vil vare i en time før du må generere et nytt token.
+
+Eksempel på riktig config:
+````
+IS_LOCALHOST="true"
+DP_RAPPORTERING_TOKEN="dhioSuoHnklnsLboasbfcS[...]"
+````
+
 ## Welcome to Remix!
 
 - [Remix Docs](https://remix.run/docs)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dette tokenet vil vare i en time før du må generere et nytt token.
 Eksempel på riktig config:
 ````
 IS_LOCALHOST="true"
-DP_RAPPORTERING_TOKEN="dhioSuoHnklnsLboasbfcS[...]"
+DP_RAPPORTERING_TOKEN="langStrengHerFraAccess_token"
 ````
 
 ## Welcome to Remix!

--- a/app/models/aktivitet.server.ts
+++ b/app/models/aktivitet.server.ts
@@ -1,5 +1,6 @@
-import { audienceDPRapportering, getSession } from "~/utils/auth.utils";
+import { getSession } from "~/utils/auth.utils";
 import { getEnv } from "~/utils/env.utils";
+import { getRapporteringOboToken } from "~/utils/obo-token.utils";
 
 export type TAktivitetType = "Arbeid" | "Syk" | "Ferie";
 
@@ -10,7 +11,10 @@ export interface IAktivitet {
   dato: string;
 }
 
-export async function lagreAktivitet(aktivitet: IAktivitet, request: Request): Promise<IAktivitet> {
+export async function lagreAktivitet(
+  aktivitet: IAktivitet,
+  request: Request
+): Promise<IAktivitet> {
   const session = await getSession(request);
 
   if (!session) {
@@ -19,7 +23,7 @@ export async function lagreAktivitet(aktivitet: IAktivitet, request: Request): P
 
   const url = `${getEnv("DP_RAPPORTERING_URL")}/aktivitet`;
 
-  const onBehalfOfToken = await session.apiToken(audienceDPRapportering);
+  const onBehalfOfToken = await getRapporteringOboToken(session);
 
   const response = await fetch(url, {
     method: "POST",

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -1,6 +1,7 @@
-import { audienceDPRapportering, getSession } from "~/utils/auth.utils";
+import { getSession } from "~/utils/auth.utils";
 import { getEnv } from "~/utils/env.utils";
 import type { IAktivitet, TAktivitetType } from "./aktivitet.server";
+import { getRapporteringOboToken } from "~/utils/obo-token.utils";
 
 export interface IRapporteringsperiode {
   id: string;
@@ -29,7 +30,7 @@ export async function hentSisteRapporteringsperiode(
     throw new Error("Feil ved henting av sessjon");
   }
 
-  const onBehalfOfToken = await session.apiToken(audienceDPRapportering);
+  const onBehalfOfToken = await getRapporteringOboToken(session);
 
   const response = await fetch(url, {
     method: "GET",

--- a/app/utils/env.utils.ts
+++ b/app/utils/env.utils.ts
@@ -9,6 +9,7 @@ interface IEnv {
   DP_RAPPORTERING_URL: string;
   AUTH_PROVIDER: string;
   IS_LOCALHOST: string;
+  DP_RAPPORTERING_TOKEN: string;
   NAIS_CLUSTER_NAME: string;
   LOCAL_TOKEN: string;
   USE_MSW: string;

--- a/app/utils/obo-token.utils.ts
+++ b/app/utils/obo-token.utils.ts
@@ -1,0 +1,12 @@
+import type { SessionWithOboProvider } from "@navikt/dp-auth/index/";
+import { audienceDPRapportering } from "./auth.utils";
+import { getEnv } from "./env.utils";
+
+export async function getRapporteringOboToken(session: SessionWithOboProvider) {
+  if (getEnv("IS_LOCALHOST") === "true" && getEnv("DP_RAPPORTERING_TOKEN")) {
+    return getEnv("DP_RAPPORTERING_TOKEN");
+  } else {
+    const token = await session.apiToken(audienceDPRapportering);
+    return token;
+  }
+}


### PR DESCRIPTION
For å kjøre API-requests fra localhost til dp-rapportering i dev må vi sette token lokalt via wonderwalled-idporten. Det er inntil videre en manuell prosess med å legge inn tokenet i .env-fila (som er .gitignoret btw), så får vi se om vi finner på noe smart noe etterhvert for å automatisere dette. 😄 

Tldr;
Legg til disse i .env for å få dette til å virke:
````
IS_LOCALHOST="true"
DP_RAPPORTERING_TOKEN="langStrengHerFraAccess_token"
````