### PR TITLE
Redigering av aktivtet

### DIFF
--- a/app/components/aktivitet-modal/AktivitetModal.module.css
+++ b/app/components/aktivitet-modal/AktivitetModal.module.css
@@ -2,43 +2,10 @@
   text-transform: capitalize;
 }
 
-.timeTypeKontainer {
+.aktivitetKontainer {
   display: flex;
   flex-direction: column;
   margin-top: var(--a-spacing-6);
-}
-
-.timeType {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border: 0;
-  width: 100%;
-  min-width: 300px;
-  cursor: pointer;
-  padding: var(--a-spacing-2) var(--a-spacing-4);
-  margin: 0 calc(var(--a-spacing-1) * -1) var(--a-spacing-2);
-  background-color: var(--a-blue-200);
-  border-radius: var(--a-spacing-6);
-}
-
-.Arbeid {
-  background-color: var(--a-blue-200);
-}
-.Arbeid:hover {
-  background-color: var(--a-blue-300);
-}
-.Syk {
-  background-color: var(--a-orange-200);
-}
-.Syk:hover {
-  background-color: var(--a-orange-300);
-}
-.Ferie {
-  background-color: var(--a-green-200);
-}
-.Ferie:hover {
-  background-color: var(--a-green-300);
 }
 
 .knappKontainer {
@@ -64,11 +31,7 @@
     font-size: var(--a-font-size-large);
   }
 
-  .timeTypeKontainer {
+  .aktivitetKontainer {
     min-width: 450px;
-  }
-
-  .timeType {
-    width: 50%;
   }
 }

--- a/app/components/aktivitet-modal/AktivitetModal.module.css
+++ b/app/components/aktivitet-modal/AktivitetModal.module.css
@@ -15,7 +15,7 @@
   margin-top: var(--a-spacing-8);
 }
 
-.aktivitetMedSletting {
+.slettKnapp {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/app/components/aktivitet-modal/AktivitetModal.module.css
+++ b/app/components/aktivitet-modal/AktivitetModal.module.css
@@ -9,6 +9,9 @@
 }
 
 .timeType {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   border: 0;
   width: 100%;
   min-width: 300px;
@@ -18,6 +21,7 @@
   background-color: var(--a-blue-200);
   border-radius: var(--a-spacing-6);
 }
+
 .Arbeid {
   background-color: var(--a-blue-200);
 }

--- a/app/components/aktivitet-modal/AktivitetModal.module.css
+++ b/app/components/aktivitet-modal/AktivitetModal.module.css
@@ -1,11 +1,11 @@
 .modalHeader {
   text-transform: capitalize;
+  margin-bottom: var(--a-spacing-6);
 }
 
 .aktivitetKontainer {
   display: flex;
   flex-direction: column;
-  margin-top: var(--a-spacing-6);
 }
 
 .knappKontainer {
@@ -13,6 +13,42 @@
   justify-content: flex-end;
   gap: var(--a-spacing-2);
   margin-top: var(--a-spacing-8);
+}
+
+.aktivitetMedSletting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 0;
+  width: 300px;
+  cursor: pointer;
+  padding: var(--a-spacing-2) var(--a-spacing-4);
+  margin: 0 calc(var(--a-spacing-1) * -1) var(--a-spacing-2);
+  background-color: var(--a-blue-200);
+  border-radius: var(--a-spacing-6);
+}
+
+.feilmelding {
+  margin-top: var(--a-spacing-4);
+}
+
+.Arbeid {
+  background-color: var(--a-blue-200);
+}
+.Arbeid:hover {
+  background-color: var(--a-blue-300);
+}
+.Syk {
+  background-color: var(--a-orange-200);
+}
+.Syk:hover {
+  background-color: var(--a-orange-300);
+}
+.Ferie {
+  background-color: var(--a-green-200);
+}
+.Ferie:hover {
+  background-color: var(--a-green-300);
 }
 
 @media screen and (min-width: 768px) {

--- a/app/components/aktivitet-modal/AktivitetModal.tsx
+++ b/app/components/aktivitet-modal/AktivitetModal.tsx
@@ -13,14 +13,11 @@ import { AktivitetRadio } from "../aktivitet-radio/AktivitetRadio";
 import { validator } from "~/utils/validering.util";
 
 import styles from "./AktivitetModal.module.css";
+import { useState } from "react";
 
 interface IProps {
   rapporteringsperiodeId: string;
-  timer?: string;
   valgtDato?: string;
-  setValgtDato: (dato: string) => void;
-  valgtAktivitet?: TAktivitetType;
-  setValgtAktivitet: (aktivitet: TAktivitetType) => void;
   modalAapen: boolean;
   setModalAapen: any;
   lukkModal: () => void;
@@ -29,7 +26,8 @@ interface IProps {
 
 export function AktivitetModal(props: IProps) {
   const { rapporteringsperiode } = useRouteLoaderData("routes/rapportering") as IRapporteringLoader;
-  const dagMedAktivitet = rapporteringsperiode.dager.find((dag) => dag.dato === props.valgtDato);
+  const harAktivitet = rapporteringsperiode.dager.find((dag) => dag.dato === props.valgtDato);
+  const [valgAktivitet, setValgtAktivitet] = useState(harAktivitet?.aktiviteter[0]?.type || "");
 
   return (
     <Modal
@@ -43,8 +41,8 @@ export function AktivitetModal(props: IProps) {
           {props.valgtDato && format(new Date(props.valgtDato), "EEEE d", { locale: nbLocale })}
         </Heading>
 
-        {dagMedAktivitet &&
-          dagMedAktivitet.aktiviteter.map((aktivitet) => (
+        {harAktivitet &&
+          harAktivitet.aktiviteter.map((aktivitet) => (
             <Form key={aktivitet.id} method="post">
               <input
                 type="text"
@@ -67,11 +65,7 @@ export function AktivitetModal(props: IProps) {
             </Form>
           ))}
 
-        <ValidatedForm
-          method="post"
-          key="lagre-ny-aktivitet"
-          validator={validator(props.valgtAktivitet!)}
-        >
+        <ValidatedForm method="post" key="lagre-ny-aktivitet" validator={validator(valgAktivitet)}>
           <input
             type="text"
             hidden
@@ -85,14 +79,18 @@ export function AktivitetModal(props: IProps) {
               <AktivitetRadio
                 name="type"
                 muligeAktiviteter={props.muligeAktiviteter}
-                verdi={props.valgtAktivitet!}
+                verdi={valgAktivitet}
+                onChange={(aktivitet: string) => setValgtAktivitet(aktivitet)}
               />
             )}
           </div>
 
-          {/* {props.valgtAktivitet === "Arbeid" && ( */}
-          <TallInput name="timer" verdi={props.timer?.replace(/\./g, ",")} />
-          {/* )} */}
+          {valgAktivitet === "Arbeid" && (
+            <TallInput
+              name="timer"
+              verdi={harAktivitet?.aktiviteter[0]?.timer?.replace(/\./g, ",")}
+            />
+          )}
 
           <div className={styles.knappKontainer}>
             <Button variant="tertiary-neutral" onClick={() => props.lukkModal()}>

--- a/app/components/aktivitet-modal/AktivitetModal.tsx
+++ b/app/components/aktivitet-modal/AktivitetModal.tsx
@@ -33,6 +33,18 @@ export function AktivitetModal(props: IProps) {
     (dag) => dag.dato === props.valgtDato
   );
 
+  function hentSlettKnappTekst() {
+    const aktivitet = valgteDatoHarAktivitet?.aktiviteter[0];
+
+    if (aktivitet?.type === "Arbeid") {
+      return `${aktivitet.type} ${periodeSomTimer(aktivitet.timer!)
+        .toString()
+        .replace(/\./g, ",")} timer`;
+    }
+
+    return `${aktivitet?.type}`;
+  }
+
   return (
     <Modal
       aria-labelledby="modal-heading"
@@ -61,9 +73,7 @@ export function AktivitetModal(props: IProps) {
                 value="slette"
                 className={classNames(styles.slettKnapp, styles[aktivitet.type])}
               >
-                <>
-                  {aktivitet.type} {periodeSomTimer(aktivitet.timer!)} timer
-                </>
+                {hentSlettKnappTekst()}
                 <TrashIcon title="a11y-title" fontSize="1.5rem" />
               </button>
             </Form>

--- a/app/components/aktivitet-modal/AktivitetModal.tsx
+++ b/app/components/aktivitet-modal/AktivitetModal.tsx
@@ -1,10 +1,16 @@
+import { TrashIcon } from "@navikt/aksel-icons";
 import { Button, Heading, Modal } from "@navikt/ds-react";
+import { Form, useRouteLoaderData } from "@remix-run/react";
 import { withZod } from "@remix-validated-form/with-zod";
 import classNames from "classnames";
+import { format } from "date-fns";
+import nbLocale from "date-fns/locale/nb";
 import { ValidatedForm } from "remix-validated-form";
+import { TallInput } from "~/components/TallInput";
 import type { TAktivitetType } from "~/models/aktivitet.server";
+import { IRapporteringLoader } from "~/routes/rapportering";
+import { periodeSomTimer } from "~/utils/periode.utils";
 import { aktivitetsvalideringArbeid, aktivitetsvalideringSykFerie } from "~/utils/validering.util";
-import { TallInput } from "../TallInput";
 
 import styles from "./AktivitetModal.module.css";
 
@@ -17,16 +23,20 @@ interface IProps {
   setValgtAktivitet: (aktivitet: TAktivitetType) => void;
   modalAapen: boolean;
   setModalAapen: any;
-  modalHeaderTekst?: string;
   lukkModal: () => void;
   muligeAktiviteter: TAktivitetType[];
 }
 
 export function AktivitetModal(props: IProps) {
+  const { rapporteringsperiode } = useRouteLoaderData("routes/rapportering") as IRapporteringLoader;
+
   const validator =
     props.valgtAktivitet === "Arbeid"
       ? withZod(aktivitetsvalideringArbeid)
       : withZod(aktivitetsvalideringSykFerie);
+
+  const dagMedAktivitet = rapporteringsperiode.dager.find((dag) => dag.dato === props.valgtDato);
+
   return (
     <Modal
       aria-labelledby="modal-heading"
@@ -37,7 +47,7 @@ export function AktivitetModal(props: IProps) {
     >
       <Modal.Content>
         <Heading spacing level="1" size="medium" id="modal-heading" className={styles.modalHeader}>
-          {props.modalHeaderTekst}
+          {props.valgtDato && format(new Date(props.valgtDato), "EEEE d", { locale: nbLocale })}
         </Heading>
         <div className={styles.timeTypeKontainer}>
           {props.muligeAktiviteter &&
@@ -50,6 +60,32 @@ export function AktivitetModal(props: IProps) {
               >
                 {aktivitet}
               </button>
+            ))}
+
+          {/* Redigering modus */}
+          {/* Todo rydd opp koden */}
+          {dagMedAktivitet &&
+            dagMedAktivitet.aktiviteter.map((aktivitet) => (
+              <Form key={aktivitet.id} method="post">
+                <input
+                  type="text"
+                  hidden
+                  name="rapporteringsperiodeId"
+                  defaultValue={props.rapporteringsperiodeId}
+                />
+                <input type="text" hidden name="aktivitetId" defaultValue={aktivitet.id} />
+                <button
+                  type="submit"
+                  name="submit"
+                  value="slette"
+                  className={classNames(styles.timeType, styles[aktivitet.type])}
+                >
+                  <>
+                    {aktivitet.type} {periodeSomTimer(aktivitet.timer!)} timer
+                  </>
+                  <TrashIcon title="a11y-title" fontSize="1.5rem" />
+                </button>
+              </Form>
             ))}
         </div>
         <ValidatedForm method="post" key="lagre-ny-aktivitet" validator={validator}>
@@ -68,7 +104,9 @@ export function AktivitetModal(props: IProps) {
             <Button variant="tertiary-neutral" onClick={() => props.lukkModal()}>
               Avbryt
             </Button>
-            <Button type="submit">Lagre</Button>
+            <Button type="submit" name="submit" value="lagre">
+              Lagre
+            </Button>
           </div>
         </ValidatedForm>
       </Modal.Content>

--- a/app/components/aktivitet-modal/AktivitetModal.tsx
+++ b/app/components/aktivitet-modal/AktivitetModal.tsx
@@ -112,9 +112,6 @@ export function AktivitetModal(props: IProps) {
           )}
 
           <div className={styles.knappKontainer}>
-            <Button variant="tertiary-neutral" onClick={() => props.lukkModal()}>
-              Avbryt
-            </Button>
             <Button type="submit" name="submit" value="lagre">
               Lagre
             </Button>

--- a/app/components/aktivitet-modal/AktivitetModal.tsx
+++ b/app/components/aktivitet-modal/AktivitetModal.tsx
@@ -18,7 +18,7 @@ interface IProps {
   rapporteringsperiodeId: string;
   valgtDato?: string;
   valgtAktivitet: string | TAktivitetType;
-  setValgtAktivitet: (aktivitet: string) => void;
+  setValgtAktivitet: (aktivitet: string | TAktivitetType) => void;
   modalAapen: boolean;
   setModalAapen: any;
   lukkModal: () => void;
@@ -29,7 +29,7 @@ export function AktivitetModal(props: IProps) {
   const { rapporteringsperiode } = useRouteLoaderData("routes/rapportering") as IRapporteringLoader;
   const actionData = useActionData();
 
-  const valgteDatoHarNoenAktivitet = rapporteringsperiode.dager.find(
+  const valgteDatoHarAktivitet = rapporteringsperiode.dager.find(
     (dag) => dag.dato === props.valgtDato
   );
 
@@ -45,8 +45,8 @@ export function AktivitetModal(props: IProps) {
           {props.valgtDato && format(new Date(props.valgtDato), "EEEE d", { locale: nbLocale })}
         </Heading>
 
-        {valgteDatoHarNoenAktivitet &&
-          valgteDatoHarNoenAktivitet.aktiviteter.map((aktivitet) => (
+        {valgteDatoHarAktivitet &&
+          valgteDatoHarAktivitet.aktiviteter.map((aktivitet) => (
             <Form key={aktivitet.id} method="post">
               <input
                 type="text"
@@ -59,7 +59,7 @@ export function AktivitetModal(props: IProps) {
                 type="submit"
                 name="submit"
                 value="slette"
-                className={classNames(styles.aktivitetMedSletting, styles[aktivitet.type])}
+                className={classNames(styles.slettKnapp, styles[aktivitet.type])}
               >
                 <>
                   {aktivitet.type} {periodeSomTimer(aktivitet.timer!)} timer

--- a/app/components/aktivitet-radio/AktivitetRadio.module.css
+++ b/app/components/aktivitet-radio/AktivitetRadio.module.css
@@ -1,0 +1,34 @@
+.aktivitet label {
+  display: flex;
+  border: 0;
+  width: 300px;
+  padding: var(--a-spacing-2) var(--a-spacing-4);
+  margin: 0 calc(var(--a-spacing-1) * -1) var(--a-spacing-2);
+  background-color: var(--a-blue-200);
+  border-radius: var(--a-spacing-6);
+}
+
+.aktivitet label span {
+  color: var(--a-text-default);
+}
+
+.Arbeid label {
+  background-color: var(--a-blue-200);
+}
+.Arbeid label:hover {
+  background-color: var(--a-blue-300);
+}
+
+.Syk label {
+  background-color: var(--a-orange-200);
+}
+.Syk label:hover {
+  background-color: var(--a-orange-300);
+}
+
+.Ferie label {
+  background-color: var(--a-green-200);
+}
+.Ferie label:hover {
+  background-color: var(--a-green-300);
+}

--- a/app/components/aktivitet-radio/AktivitetRadio.tsx
+++ b/app/components/aktivitet-radio/AktivitetRadio.tsx
@@ -11,23 +11,23 @@ export interface IProps {
   label?: string;
   verdi?: string;
   muligeAktiviteter: TAktivitetType[];
+  onChange: (aktivitet: string) => void;
 }
 
 export function AktivitetRadio(props: IProps) {
   const { error, getInputProps } = useField(props.name);
-  const [value, setValue] = useState(props.verdi || "");
 
-  const inputProps: any = getInputProps({
+  const inputProps: { type: string; value: string } = getInputProps({
     type: "radio",
-    value,
+    value: props.verdi || "",
   });
 
   return (
     <RadioGroup
       legend={props.label}
-      error={!value ? error : undefined}
+      error={!inputProps.value ? error : undefined}
       {...inputProps}
-      onChange={(verdi) => setValue(verdi)}
+      onChange={props.onChange}
     >
       {props.muligeAktiviteter.map((aktivitet) => (
         <Radio

--- a/app/components/aktivitet-radio/AktivitetRadio.tsx
+++ b/app/components/aktivitet-radio/AktivitetRadio.tsx
@@ -1,0 +1,43 @@
+import { Radio, RadioGroup } from "@navikt/ds-react";
+import classNames from "classnames";
+import { useField } from "remix-validated-form";
+import { TAktivitetType } from "~/models/aktivitet.server";
+
+import { useState } from "react";
+import styles from "./AktivitetRadio.module.css";
+
+export interface IProps {
+  name: string;
+  label?: string;
+  verdi?: string;
+  muligeAktiviteter: TAktivitetType[];
+}
+
+export function AktivitetRadio(props: IProps) {
+  const { error, getInputProps } = useField(props.name);
+  const [value, setValue] = useState(props.verdi || "");
+
+  const inputProps: any = getInputProps({
+    type: "radio",
+    value,
+  });
+
+  return (
+    <RadioGroup
+      legend={props.label}
+      error={!value ? error : undefined}
+      {...inputProps}
+      onChange={(verdi) => setValue(verdi)}
+    >
+      {props.muligeAktiviteter.map((aktivitet) => (
+        <Radio
+          key={aktivitet}
+          className={classNames(styles.aktivitet, styles[aktivitet])}
+          value={aktivitet}
+        >
+          {aktivitet}
+        </Radio>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/app/components/kalender/Kalender.module.css
+++ b/app/components/kalender/Kalender.module.css
@@ -1,6 +1,7 @@
 .kalender {
   margin-left: calc(var(--a-spacing-2) * -1);
   width: calc(var(--a-spacing-4) + 100%);
+  margin-bottom: var(--a-spacing-20);
 }
 
 .kalenderUkedagKontainer {

--- a/app/components/kalender/Kalender.tsx
+++ b/app/components/kalender/Kalender.tsx
@@ -62,19 +62,15 @@ export function Kalender(props: IProps) {
               >
                 <p>{format(new Date(dag.dato), "dd")}</p>.
               </button>
-              {harAktivitet && (
+              {harAktivitet && dag.aktiviteter[0].type === "Arbeid" && (
                 <div
                   className={classNames(styles.kalenderDatoAktivitet, {
                     [styles.timerArbeid]: harAktivitet && dag.aktiviteter[0].type === "Arbeid",
-                    [styles.timerSykdom]: harAktivitet && dag.aktiviteter[0].type === "Syk",
-                    [styles.timerFerie]: harAktivitet && dag.aktiviteter[0].type === "Ferie",
                   })}
                 >
                   {dag.aktiviteter.some((aktivitet) => aktivitet.type === "Arbeid") && (
                     <> {timer.toString().replace(/\./g, ",")}t</>
                   )}
-                  {dag.aktiviteter.some((aktivitet) => aktivitet.type === "Syk") && <>Syk</>}
-                  {dag.aktiviteter.some((aktivitet) => aktivitet.type === "Ferie") && <>Ferie</>}
                 </div>
               )}
             </div>

--- a/app/models/aktivitet.server.ts
+++ b/app/models/aktivitet.server.ts
@@ -14,7 +14,7 @@ export async function lagreAktivitet(
   rapporteringsperiodeId: string,
   aktivitet: IAktivitet,
   request: Request
-): Promise<IAktivitet> {
+): Promise<Response> {
   const session = await getSession(request);
 
   if (!session) {
@@ -27,7 +27,7 @@ export async function lagreAktivitet(
 
   const onBehalfOfToken = await getRapporteringOboToken(session);
 
-  const response = await fetch(url, {
+  return await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -36,15 +36,6 @@ export async function lagreAktivitet(
     },
     body: JSON.stringify({ ...aktivitet }),
   });
-
-  if (!response.ok) {
-    throw new Response(`Feil ved lagring av aktivitet til ${url}`, {
-      status: response.status,
-      statusText: response.statusText,
-    });
-  }
-
-  return await response.json();
 }
 
 export async function sletteAktivitet(

--- a/app/models/aktivitet.server.ts
+++ b/app/models/aktivitet.server.ts
@@ -46,3 +46,30 @@ export async function lagreAktivitet(
 
   return await response.json();
 }
+
+export async function sletteAktivitet(
+  rapporteringsperiodeId: string,
+  aktivitetId: String,
+  request: Request
+): Promise<Response> {
+  const session = await getSession(request);
+
+  if (!session) {
+    throw new Error("Feil ved henting av sessjon");
+  }
+
+  const url = `${getEnv(
+    "DP_RAPPORTERING_URL"
+  )}/rapporteringsperioder/${rapporteringsperiodeId}/aktivitet/${aktivitetId}`;
+
+  const onBehalfOfToken = await getRapporteringOboToken(session);
+
+  return await fetch(url, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${onBehalfOfToken}`,
+    },
+  });
+}

--- a/app/models/aktivitet.server.ts
+++ b/app/models/aktivitet.server.ts
@@ -41,10 +41,6 @@ export async function sletteAktivitet(
 ): Promise<Response> {
   const session = await getSession(request);
 
-  if (!session) {
-    throw new Error("Feil ved henting av sessjon");
-  }
-
   const url = `${getEnv(
     "DP_RAPPORTERING_URL"
   )}/rapporteringsperioder/${rapporteringsperiodeId}/aktivitet/${aktivitetId}`;

--- a/app/routes/rapportering-sendt.tsx
+++ b/app/routes/rapportering-sendt.tsx
@@ -1,6 +1,7 @@
-import { Left } from "@navikt/ds-icons";
 import { Heading } from "@navikt/ds-react";
 import { RemixLink } from "~/components/RemixLink";
+import { ArrowLeftIcon } from "@navikt/aksel-icons";
+
 import styles from "./rapportering.module.css";
 
 export default function RapporteringSendt() {
@@ -18,7 +19,7 @@ export default function RapporteringSendt() {
           Du har sendt inn rapporteringen til NAV.
         </Heading>
         <br />
-        <RemixLink to="" as="Button" variant="primary" icon={<Left />}>
+        <RemixLink to="" as="Button" variant="primary" icon={<ArrowLeftIcon fontSize="1.5rem" />}>
           Gå til Mine side
         </RemixLink>
       </main>

--- a/app/routes/rapportering._index.tsx
+++ b/app/routes/rapportering._index.tsx
@@ -34,7 +34,7 @@ export async function action({ request }: ActionArgs) {
       );
 
       if (!slettAktivitetResponse.ok) {
-        return json({ error: "Det har skjedd en feil ved sletting, prøv igjen" });
+        return json({ error: "Det har skjedd en feil ved sletting, prøv igjen." });
       }
 
       return {};
@@ -79,7 +79,7 @@ export async function action({ request }: ActionArgs) {
       );
 
       if (!lagreAktivitetResponse.ok) {
-        return json({ error: "Neon gikk feil med lagring av aktivitet, prøv igjen." });
+        return json({ error: "Noen gikk feil med lagring av aktivitet, prøv igjen." });
       }
 
       return json({ lagret: true });

--- a/app/routes/rapportering._index.tsx
+++ b/app/routes/rapportering._index.tsx
@@ -78,9 +78,7 @@ export async function action({ request }: ActionArgs) {
 export default function Rapportering() {
   const { rapporteringsperiode } = useRouteLoaderData("routes/rapportering") as IRapporteringLoader;
 
-  const [valgtAktivitet, setValgtAktivitet] = useState<TAktivitetType | undefined>(undefined);
   const [valgtDato, setValgtDato] = useState<string | undefined>(undefined);
-  const [timer] = useState<string | undefined>(undefined);
   const [modalAapen, setModalAapen] = useState(false);
   const [muligeAktiviteter, setMuligeAktiviteter] = useState<TAktivitetType[]>([]);
   const { hentAppTekstMedId } = useSanity();
@@ -101,7 +99,6 @@ export default function Rapportering() {
   }
 
   function lukkModal() {
-    setValgtAktivitet(undefined);
     setValgtDato(undefined);
     setModalAapen(false);
   }
@@ -130,16 +127,13 @@ export default function Rapportering() {
 
       <AktivitetModal
         rapporteringsperiodeId={rapporteringsperiode.id}
-        timer={timer}
         valgtDato={valgtDato}
-        setValgtDato={setValgtDato}
-        valgtAktivitet={valgtAktivitet}
-        setValgtAktivitet={setValgtAktivitet}
         modalAapen={modalAapen}
         setModalAapen={setModalAapen}
         lukkModal={lukkModal}
         muligeAktiviteter={muligeAktiviteter}
       />
+
       <div className={styles.registertMeldeperiodeKontainer}>
         <p>Sammenlagt for meldeperioden:</p>
         <AktivitetOppsummering />

--- a/app/routes/rapportering._index.tsx
+++ b/app/routes/rapportering._index.tsx
@@ -92,7 +92,7 @@ export default function Rapportering() {
   const actionData = useActionData();
 
   const [valgtDato, setValgtDato] = useState<string | undefined>(undefined);
-  const [valgtAktivitet, setValgtAktivitet] = useState("");
+  const [valgtAktivitet, setValgtAktivitet] = useState<TAktivitetType | string>("");
   const [modalAapen, setModalAapen] = useState(false);
   const [muligeAktiviteter, setMuligeAktiviteter] = useState<TAktivitetType[]>([]);
   const { hentAppTekstMedId } = useSanity();

--- a/app/routes/rapportering._index.tsx
+++ b/app/routes/rapportering._index.tsx
@@ -1,10 +1,9 @@
-import { Left, Right } from "@navikt/ds-icons";
+import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
 import { Heading, Modal } from "@navikt/ds-react";
 import { json, type ActionArgs } from "@remix-run/node";
-import { useActionData, useRouteLoaderData } from "@remix-run/react";
+import { useRouteLoaderData } from "@remix-run/react";
 import { withZod } from "@remix-validated-form/with-zod";
 import { format, isFriday, isPast, isToday } from "date-fns";
-import nbLocale from "date-fns/locale/nb";
 import { useEffect, useState } from "react";
 import { validationError } from "remix-validated-form";
 import { serialize } from "tinyduration";
@@ -14,7 +13,7 @@ import { AktivitetOppsummering } from "~/components/aktivitet-oppsummering/Aktiv
 import { Kalender } from "~/components/kalender/Kalender";
 import { useSanity } from "~/hooks/useSanity";
 import type { TAktivitetType } from "~/models/aktivitet.server";
-import { lagreAktivitet } from "~/models/aktivitet.server";
+import { lagreAktivitet, sletteAktivitet } from "~/models/aktivitet.server";
 import { aktivitetsvalideringArbeid, aktivitetsvalideringSykFerie } from "~/utils/validering.util";
 import { IRapporteringLoader } from "./rapportering";
 
@@ -22,50 +21,72 @@ import styles from "./rapportering.module.css";
 
 export async function action({ request }: ActionArgs) {
   const formdata = await request.formData();
-  const isArbeid = formdata.get("type") === "Arbeid";
-  const validator = isArbeid
-    ? withZod(aktivitetsvalideringArbeid)
-    : withZod(aktivitetsvalideringSykFerie);
+  const submitKnapp = formdata.get("submit");
 
-  const inputVerdier = await validator.validate(formdata);
+  switch (submitKnapp) {
+    case "slette": {
+      const rapporteringsperiodeId = formdata.get("rapporteringsperiodeId") as string;
+      const aktivitetId = formdata.get("aktivitetId") as string;
 
-  if (inputVerdier.error) {
-    return validationError(inputVerdier.error);
+      const slettAktivitetResponse = await sletteAktivitet(
+        rapporteringsperiodeId,
+        aktivitetId,
+        request
+      );
+
+      if (!slettAktivitetResponse.ok) {
+        return json({ error: "Det har gått noe feil med sletting, prøv igjen" });
+      }
+
+      return {};
+    }
+
+    case "lagre": {
+      const isArbeid = formdata.get("type") === "Arbeid";
+      const validator = isArbeid
+        ? withZod(aktivitetsvalideringArbeid)
+        : withZod(aktivitetsvalideringSykFerie);
+
+      const inputVerdier = await validator.validate(formdata);
+
+      if (inputVerdier.error) {
+        return validationError(inputVerdier.error);
+      }
+
+      const { rapporteringsperiodeId, type, dato, timer: tid } = inputVerdier.submittedData;
+
+      if (isArbeid) {
+        const delt = tid.split(",");
+        const timer = delt[0] || 0;
+        const minutter = delt[1] || 0;
+        const aktivitet = {
+          type,
+          dato,
+          timer: serialize({
+            hours: timer,
+            minutes: minutter * 6,
+          }),
+        };
+
+        return await lagreAktivitet(rapporteringsperiodeId, aktivitet, request);
+      }
+
+      const aktivitet = {
+        type,
+        dato,
+      };
+
+      await lagreAktivitet(rapporteringsperiodeId, aktivitet, request);
+    }
   }
-
-  const { rapporteringsperiodeId, type, dato, timer: tid } = inputVerdier.submittedData;
-  if (isArbeid) {
-    const delt = tid.split(",");
-    const timer = delt[0] || 0;
-    const minutter = delt[1] || 0;
-    const aktivitet = {
-      type,
-      dato,
-      timer: serialize({
-        hours: timer,
-        minutes: minutter * 6,
-      }),
-    };
-    return await lagreAktivitet(rapporteringsperiodeId, aktivitet, request);
-  }
-  const aktivitet = {
-    type,
-    dato,
-  };
-
-  await lagreAktivitet(rapporteringsperiodeId, aktivitet, request);
-
-  return json({ aktivitetLagret: true });
 }
 
 export default function Rapportering() {
   const { rapporteringsperiode } = useRouteLoaderData("routes/rapportering") as IRapporteringLoader;
-  const actionData = useActionData();
 
   const [valgtAktivitet, setValgtAktivitet] = useState<TAktivitetType | undefined>(undefined);
   const [valgtDato, setValgtDato] = useState<string | undefined>(undefined);
   const [timer] = useState<string | undefined>(undefined);
-  const [modalHeaderTekst, setModalHeaderTekst] = useState("");
   const [modalAapen, setModalAapen] = useState(false);
   const [muligeAktiviteter, setMuligeAktiviteter] = useState<TAktivitetType[]>([]);
   const { hentAppTekstMedId } = useSanity();
@@ -80,24 +101,15 @@ export default function Rapportering() {
     );
   }, [rapporteringsperiode.dager, valgtDato]);
 
-  useEffect(() => {
-    if (actionData) {
-      lukkModal();
-    }
-  }, [actionData]);
-
   function aapneModal(dato: string) {
     setValgtDato(dato);
     setModalAapen(true);
-
-    setModalHeaderTekst(`${format(new Date(dato), "EEEE d", { locale: nbLocale })}`);
   }
 
   function lukkModal() {
     setValgtAktivitet(undefined);
     setValgtDato(undefined);
     setModalAapen(false);
-    setModalHeaderTekst("");
   }
 
   // Vet ikke om det er slik det skal være, vi må finne ut av det
@@ -131,7 +143,6 @@ export default function Rapportering() {
         setValgtAktivitet={setValgtAktivitet}
         modalAapen={modalAapen}
         setModalAapen={setModalAapen}
-        modalHeaderTekst={modalHeaderTekst}
         lukkModal={lukkModal}
         muligeAktiviteter={muligeAktiviteter}
       />
@@ -141,7 +152,7 @@ export default function Rapportering() {
       </div>
 
       <div className={styles.navigasjonKontainer}>
-        <RemixLink to="" as="Button" variant="secondary" icon={<Left />}>
+        <RemixLink to="" as="Button" variant="secondary" icon={<ArrowLeftIcon fontSize="1.5rem" />}>
           Mine side
         </RemixLink>
         <RemixLink
@@ -151,7 +162,7 @@ export default function Rapportering() {
           }
           as="Button"
           variant="primary"
-          icon={<Right />}
+          icon={<ArrowRightIcon fontSize="1.5rem" />}
           iconPosition="right"
         >
           Neste steg

--- a/app/routes/rapportering._index.tsx
+++ b/app/routes/rapportering._index.tsx
@@ -2,8 +2,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
 import { Heading, Modal } from "@navikt/ds-react";
 import { json, type ActionArgs } from "@remix-run/node";
 import { useRouteLoaderData } from "@remix-run/react";
-import { withZod } from "@remix-validated-form/with-zod";
-import { format, isFriday, isPast, isToday } from "date-fns";
+import { isFriday, isPast, isToday } from "date-fns";
 import { useEffect, useState } from "react";
 import { validationError } from "remix-validated-form";
 import { serialize } from "tinyduration";
@@ -14,7 +13,7 @@ import { Kalender } from "~/components/kalender/Kalender";
 import { useSanity } from "~/hooks/useSanity";
 import type { TAktivitetType } from "~/models/aktivitet.server";
 import { lagreAktivitet, sletteAktivitet } from "~/models/aktivitet.server";
-import { aktivitetsvalideringArbeid, aktivitetsvalideringSykFerie } from "~/utils/validering.util";
+import { validator } from "~/utils/validering.util";
 import { IRapporteringLoader } from "./rapportering";
 
 import styles from "./rapportering.module.css";
@@ -42,12 +41,7 @@ export async function action({ request }: ActionArgs) {
     }
 
     case "lagre": {
-      const isArbeid = formdata.get("type") === "Arbeid";
-      const validator = isArbeid
-        ? withZod(aktivitetsvalideringArbeid)
-        : withZod(aktivitetsvalideringSykFerie);
-
-      const inputVerdier = await validator.validate(formdata);
+      const inputVerdier = await validator("Arbeid").validate(formdata);
 
       if (inputVerdier.error) {
         return validationError(inputVerdier.error);
@@ -55,7 +49,7 @@ export async function action({ request }: ActionArgs) {
 
       const { rapporteringsperiodeId, type, dato, timer: tid } = inputVerdier.submittedData;
 
-      if (isArbeid) {
+      if (formdata.get("type") === "Arbeid") {
         const delt = tid.split(",");
         const timer = delt[0] || 0;
         const minutter = delt[1] || 0;

--- a/app/routes/rapportering.module.css
+++ b/app/routes/rapportering.module.css
@@ -19,7 +19,7 @@
 }
 
 .registertMeldeperiodeKontainer {
-  margin-top: var(--a-spacing-12);
+  margin-top: var(--a-spacing-10);
 }
 
 .navigasjonKontainer {

--- a/app/routes/rapportering.send-inn-ikke-tilgjengelig.tsx
+++ b/app/routes/rapportering.send-inn-ikke-tilgjengelig.tsx
@@ -1,4 +1,4 @@
-import { Left, Right } from "@navikt/ds-icons";
+import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
 import { Checkbox, Heading, Ingress } from "@navikt/ds-react";
 import { useRouteLoaderData } from "@remix-run/react";
 import { format, isFriday } from "date-fns";
@@ -43,14 +43,19 @@ export default function RapporteringSendInnIkkeTilgjengelig() {
       </div>
 
       <div className={styles.navigasjonKontainer}>
-        <RemixLink to="/rapportering" as="Button" variant="secondary" icon={<Left />}>
+        <RemixLink
+          to="/rapportering"
+          as="Button"
+          variant="secondary"
+          icon={<ArrowLeftIcon fontSize="1.5rem" />}
+        >
           Forrige steg
         </RemixLink>
         <RemixLink
           to=""
           as="Button"
           variant="primary"
-          icon={<Right />}
+          icon={<ArrowRightIcon fontSize="1.5rem" />}
           iconPosition="right"
           disabled
         >

--- a/app/routes/rapportering.send-inn.tsx
+++ b/app/routes/rapportering.send-inn.tsx
@@ -1,13 +1,13 @@
-import { Left, Right } from "@navikt/ds-icons";
+import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
 import { Alert, BodyShort, Button, Heading, ReadMore } from "@navikt/ds-react";
 import { ActionArgs, json, redirect } from "@remix-run/node";
 import { Form, useActionData, useRouteLoaderData } from "@remix-run/react";
+import { logger } from "server/logger";
+import invariant from "tiny-invariant";
 import { RemixLink } from "~/components/RemixLink";
 import { AktivitetOppsummering } from "~/components/aktivitet-oppsummering/AktivitetOppsummering";
-import { IRapporteringLoader } from "./rapportering";
-import invariant from "tiny-invariant";
 import { godkjennPeriode } from "~/models/rapporteringsperiode.server";
-import { logger } from "server/logger";
+import { IRapporteringLoader } from "./rapportering";
 
 import styles from "./rapportering.module.css";
 
@@ -72,10 +72,20 @@ export default function RapporteringSendInn() {
         />
 
         <div className={styles.navigasjonKontainer}>
-          <RemixLink to="/rapportering" as="Button" variant="secondary" icon={<Left />}>
+          <RemixLink
+            to="/rapportering"
+            as="Button"
+            variant="secondary"
+            icon={<ArrowLeftIcon fontSize="1.5rem" />}
+          >
             Forrige steg
           </RemixLink>
-          <Button type="submit" variant="primary" icon={<Right />} iconPosition="right">
+          <Button
+            type="submit"
+            variant="primary"
+            icon={<ArrowRightIcon fontSize="1.5rem" />}
+            iconPosition="right"
+          >
             Send til nav
           </Button>
         </div>

--- a/app/utils/validering.util.ts
+++ b/app/utils/validering.util.ts
@@ -17,7 +17,7 @@ const aktivitetsvalideringArbeid = z.object({
 
 const aktivitetsvalideringSykFerie = aktivitetsvalideringArbeid.partial({ timer: true });
 
-export function validator(aktivitetType: TAktivitetType) {
+export function validator(aktivitetType: TAktivitetType | string) {
   return aktivitetType === "Arbeid"
     ? withZod(aktivitetsvalideringArbeid)
     : withZod(aktivitetsvalideringSykFerie);

--- a/app/utils/validering.util.ts
+++ b/app/utils/validering.util.ts
@@ -1,6 +1,8 @@
+import { withZod } from "@remix-validated-form/with-zod";
 import { z } from "zod";
+import { TAktivitetType } from "~/models/aktivitet.server";
 
-export const aktivitetsvalideringArbeid = z.object({
+const aktivitetsvalideringArbeid = z.object({
   type: z.enum(["Arbeid", "Syk", "Ferie"], {
     errorMap: () => ({ message: "Du må velge et aktivitet" }),
   }),
@@ -13,4 +15,10 @@ export const aktivitetsvalideringArbeid = z.object({
     .regex(new RegExp("^\\d*(,)?\\d*$"), "Det må være et gyldig tall"), // Regex for å matche tall med komma seperator
 });
 
-export const aktivitetsvalideringSykFerie = aktivitetsvalideringArbeid.partial({ timer: true });
+const aktivitetsvalideringSykFerie = aktivitetsvalideringArbeid.partial({ timer: true });
+
+export function validator(aktivitetType: TAktivitetType) {
+  return aktivitetType === "Arbeid"
+    ? withZod(aktivitetsvalideringArbeid)
+    : withZod(aktivitetsvalideringSykFerie);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "dp-rapportering-frontend",
       "dependencies": {
+        "@navikt/aksel-icons": "^4.0.0",
         "@navikt/dp-auth": "^0.3.3",
         "@navikt/ds-css": "^2.1.7",
-        "@navikt/ds-icons": "^3.1.3",
         "@navikt/ds-react": "^2.1.7",
         "@navikt/nav-dekoratoren-moduler": "^2.0.1",
         "@portabletext/types": "^2.0.2",
@@ -2636,9 +2635,9 @@
       }
     },
     "node_modules/@navikt/aksel-icons": {
-      "version": "2.9.8",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/2.9.8/04e4868d2f8f1022b52e9de54668127f6d0f5052",
-      "integrity": "sha512-HANk2yejzzQxj4UefLg5Q8YXqkwh98SN98fNJUIlfonnh1bla1XB2h690QZJiY5SghHDnb2RGo/aojc8BwI8kQ==",
+      "version": "4.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/4.0.0/df5ca613a431e17acbf2a63dff7c73c4a6deec76",
+      "integrity": "sha512-Lz1h45z26U+D4HdaiM3MevyNTwrJlOBGDcu7ZxNnESeUYRchr5+7Th53nc8hBEjxOv/FOADLncthLd8aVcNDDA==",
       "license": "MIT"
     },
     "node_modules/@navikt/dp-auth": {
@@ -2663,16 +2662,6 @@
       "integrity": "sha512-6MnIJpH/pX9VYXGcO2hUn9WWqUTk1WdIiPVQQbj3jTZhUKNwnT2bofcB+OrIfCST9o0qDyYeGVfVsuAyQpZxRA==",
       "license": "MIT"
     },
-    "node_modules/@navikt/ds-icons": {
-      "version": "3.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/3.1.3/6f0b23311a383d8cad94c291d49c7a98b07a5dbc",
-      "integrity": "sha512-SImOgyYsaLy9H4DBSTeQDCaLSpPZ2djZwc3cOSGLEbSEr0ZX/au0yoRLqg9v/Py8RnuxWzVGanXfywK5Y9G3yA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^17.0.30 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@navikt/ds-react": {
       "version": "2.9.8",
       "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.9.8/73242362d3e36916cac4ab99b14994a89c4e7737",
@@ -2693,6 +2682,12 @@
         "@types/react": "^17.0.30 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/@navikt/ds-react/node_modules/@navikt/aksel-icons": {
+      "version": "2.9.8",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/2.9.8/04e4868d2f8f1022b52e9de54668127f6d0f5052",
+      "integrity": "sha512-HANk2yejzzQxj4UefLg5Q8YXqkwh98SN98fNJUIlfonnh1bla1XB2h690QZJiY5SghHDnb2RGo/aojc8BwI8kQ==",
+      "license": "MIT"
     },
     "node_modules/@navikt/ds-react/node_modules/@navikt/ds-icons": {
       "version": "2.9.8",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "pre-commit": "lint-staged && npm run typecheck"
   },
   "dependencies": {
+    "@navikt/aksel-icons": "^4.0.0",
     "@navikt/dp-auth": "^0.3.3",
     "@navikt/ds-css": "^2.1.7",
-    "@navikt/ds-icons": "^3.1.3",
     "@navikt/ds-react": "^2.1.7",
     "@navikt/nav-dekoratoren-moduler": "^2.0.1",
     "@portabletext/types": "^2.0.2",


### PR DESCRIPTION
Det har blitt veldig mange filer som ble endret her siden de henger sammen. Skulle ha splittet endringene i mindre PRèr, beklager. 

Her er hva som ble gjort:
- Vis aktivitet i modalen hvis den finnes fra før av med muligheter for å slette den.
- Forenklet logikken for å vise header tekst i modalen
- Aktivitets modalen har nå to forskjellige form, en for lagre aktivitet og en for sletting.
- Logikk for å kunne vite om bruker legger til ny aktivitet eller sletter eksisterende aktivitet.
- Konverterer mulige aktivteter fra vanlig knapp til Radio for mer semantisk html og muligheter for å kunne vise feilmelding.
- Returner hele Promise isteden for å kaste en feil, den var litt for voldsomt. Muligens kunne vært løst med error-boundary isteden for return en json object med feilmelding.
- Erstatter `ds-icons`med `aksel-icons`
- Lukker modalen automatisk hvis lagring gikk greit


Modal auto close ved lagring av aktivitet
![ny-aktivitet-med-auto-close](https://github.com/navikt/dp-rapportering-frontend/assets/110396878/8bd46370-470d-4778-80c9-2a83d694be44)

Slett en aktivitet
![slett-aktivitet](https://github.com/navikt/dp-rapportering-frontend/assets/110396878/f274d09e-0aec-4d7b-8da8-e226833d7fb3)

Feil ved sletting
![feil-ved-sletting](https://github.com/navikt/dp-rapportering-frontend/assets/110396878/5118302c-1c54-4325-979a-aded96e724aa)

Feil ved lagring
![feil-ved-lagring](https://github.com/navikt/dp-rapportering-frontend/assets/110396878/e0333369-679f-47c2-94ec-a60e1b0444f1)
