### PR TITLE
Flere tester + default håndtering på action når vi har switch

### DIFF
--- a/app/routes/rapportering.periode.$rapporteringsperiodeId.fyll-ut.tsx
+++ b/app/routes/rapportering.periode.$rapporteringsperiodeId.fyll-ut.tsx
@@ -1,6 +1,6 @@
 import { InformationSquareIcon } from "@navikt/aksel-icons";
 import { BodyLong, Heading } from "@navikt/ds-react";
-import type { ActionFunctionArgs } from "@remix-run/node";
+import { json, type ActionFunctionArgs } from "@remix-run/node";
 import { useActionData, useSearchParams } from "@remix-run/react";
 import { useEffect, useRef, useState } from "react";
 import invariant from "tiny-invariant";
@@ -32,6 +32,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     case "lagre": {
       return await validerOgLagreAktivitet(onBehalfOfToken, aktivitetsType, periodeId, formdata);
+    }
+
+    default: {
+      return json({
+        status: "error",
+        error: {
+          statusCode: 500,
+          statusText: "Det skjedde en feil.",
+        },
+      });
     }
   }
 }

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -5,14 +5,17 @@ import { rapporteringsperioderResponse } from "./api-routes/rapporteringsperiode
 import { sanityResponse } from "./api-routes/sanityResponse";
 
 export const handlers = [
+  // Hent alle rapporteringsperioder
   rest.get(`${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder`, (req, res, ctx) => {
     return res(ctx.json(rapporteringsperioderResponse));
   }),
 
+  // Hent gjeldende rapporteringsperiode
   rest.get(`${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/gjeldende`, (req, res, ctx) => {
     return res(ctx.json(gjeldendePeriodeResponse));
   }),
 
+  // Godkjenn rapporteringsperiode
   rest.post(
     `${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/:rapporteringsperioderId/godkjenn`,
     (req, res, ctx) => {
@@ -20,6 +23,15 @@ export const handlers = [
     }
   ),
 
+  // Avgodkjenn rapporteringsperiode
+  rest.post(
+    `${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/:rapporteringsperioderId/avgodkjenn`,
+    (req, res, ctx) => {
+      return res(ctx.status(200));
+    }
+  ),
+
+  // Hent spesifikk rapporteringsperiode
   rest.get(
     `${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/:rapporteringsperioderId`,
     (req, res, ctx) => {
@@ -28,6 +40,32 @@ export const handlers = [
       );
 
       return res(ctx.json(rapporteringPeriode));
+    }
+  ),
+
+  // Start korrigering av rapporteringsperiode
+  rest.post(
+    `${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/:rapporteringsperioderId/korrigering`,
+    (req, res, ctx) => {
+      return res(ctx.json(rapporteringsperioderResponse[1]));
+    }
+  ),
+
+  // Lagre en aktivitet
+  rest.post(
+    `${getEnv("DP_RAPPORTERING_URL")}/rapporteringsperioder/:rapporteringsperioderId/aktivitet`,
+    (req, res, ctx) => {
+      return res(ctx.status(204));
+    }
+  ),
+
+  // Slett en aktivitet
+  rest.delete(
+    `${getEnv(
+      "DP_RAPPORTERING_URL"
+    )}/rapporteringsperioder/:rapporteringsperioderId/aktivitet/:aktivitetId`,
+    (req, res, ctx) => {
+      return res(ctx.status(204));
     }
   ),
 

--- a/tests/routes/rapportering.periode.$rapporteringsperiodeId.avgodkjenn.api.test.ts
+++ b/tests/routes/rapportering.periode.$rapporteringsperiodeId.avgodkjenn.api.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { rest } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { loader } from "~/routes/rapportering.periode.$rapporteringsperiodeId.avgodkjenn";
+import { server } from "../../mocks/server";
+import { endSessionMock, mockSession } from "../helpers/auth-helper";
+import { catchErrorResponse } from "../helpers/response-helper";
+import { rapporteringsperioderResponse } from "mocks/api-routes/rapporteringsperioderResponse";
+import { redirect } from "@remix-run/node";
+
+describe("Avgodkjenn periode", () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+  afterAll(() => server.close());
+  afterEach(() => {
+    server.resetHandlers();
+    endSessionMock();
+  });
+
+  describe("Loader: ", () => {
+    const testParams = {
+      rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+    };
+
+    test("Skal redirecte etter avgodkjenning av periode", async () => {
+      mockSession();
+
+      const response = await loader({
+        request: new Request("http://localhost:3000"),
+        params: testParams,
+        context: {},
+      });
+
+      expect(response).toEqual(
+        redirect(`/rapportering/periode/${rapporteringsperioderResponse[0].id}/fyll-ut`)
+      );
+    });
+
+    test("Skal feile hvis kallet til den bestemte rapporteringsperiode feiler", async () => {
+      server.use(
+        rest.post(
+          `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/${testParams.rapporteringsperiodeId}/avgodkjenn`,
+          (_, res, ctx) => {
+            return res.once(
+              ctx.status(500),
+              ctx.json({
+                errorMessage: `Server Error`,
+              })
+            );
+          }
+        )
+      );
+
+      mockSession();
+
+      const response = await catchErrorResponse(() =>
+        loader({
+          request: new Request("http://localhost:3000"),
+          params: testParams,
+          context: {},
+        })
+      );
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/rapportering.periode.$rapporteringsperiodeId.fyll-ut.api.test.ts
+++ b/tests/routes/rapportering.periode.$rapporteringsperiodeId.fyll-ut.api.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+import { rest } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { action } from "~/routes/rapportering.periode.$rapporteringsperiodeId.fyll-ut";
+import { rapporteringsperioderResponse } from "../../mocks/api-routes/rapporteringsperioderResponse";
+import { server } from "../../mocks/server";
+import { endSessionMock, mockSession } from "../helpers/auth-helper";
+
+describe("Fyll ut rapporteringsperiode", () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+  afterAll(() => server.close());
+  afterEach(() => {
+    server.resetHandlers();
+    endSessionMock();
+  });
+
+  describe("Action", () => {
+    const testAktivitet = {
+      id: "4a49e571-6384-4eab-9c2e-3f4d48d30b9b",
+      type: "Arbeid",
+      timer: "5", // Dette omgjøres til en ISO-8601 periode før den sendes til backend, sluttbruker skriver inn vanlige tall
+      dato: "2023-05-02",
+    };
+
+    describe("Lagre aktivitet", () => {
+      const testBody = {
+        aktivitetId: testAktivitet.id,
+        type: testAktivitet.type,
+        dato: testAktivitet.dato,
+        timer: testAktivitet.timer,
+        submit: "lagre",
+      };
+
+      const testParams = {
+        ident: "1234",
+        rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+      };
+
+      test("burde kunne lagre en aktivitet", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response.status).toBe("success");
+      });
+
+      test("burde feile hvis backend feiler", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        server.use(
+          rest.post(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/:rapporteringsperioderId/aktivitet`,
+            (req, res, ctx) => {
+              return res.once(
+                ctx.status(500),
+                ctx.json({
+                  errorMessage: `Server Error`,
+                })
+              );
+            }
+          )
+        );
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response.status).toBe("error");
+      });
+    });
+
+    describe("Slette aktivitet", () => {
+      const testBody = {
+        aktivitetId: testAktivitet.id,
+        type: testAktivitet.type,
+        dato: testAktivitet.dato,
+        timer: testAktivitet.timer,
+        submit: "slette",
+      };
+      const testParams = {
+        ident: "1234",
+        rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+      };
+
+      test("burde kunne slette en aktivitet", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response.status).toBe("success");
+      });
+
+      test("burde feile hvis backend feiler", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        server.use(
+          rest.delete(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/:rapporteringsperioderId/aktivitet/:aktivitetId`,
+            (req, res, ctx) => {
+              return res.once(
+                ctx.status(500),
+                ctx.json({
+                  errorMessage: `Server Error`,
+                })
+              );
+            }
+          )
+        );
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response.status).toBe("error");
+      });
+    });
+  });
+});

--- a/tests/routes/rapportering.periode.$rapporteringsperiodeId.korriger.api.test.ts
+++ b/tests/routes/rapportering.periode.$rapporteringsperiodeId.korriger.api.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { rest } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { loader } from "~/routes/rapportering.periode.$rapporteringsperiodeId.korriger";
+import { server } from "../../mocks/server";
+import { endSessionMock, mockSession } from "../helpers/auth-helper";
+import { catchErrorResponse } from "../helpers/response-helper";
+import { rapporteringsperioderResponse } from "mocks/api-routes/rapporteringsperioderResponse";
+import { redirect } from "@remix-run/node";
+
+describe("Start korrigering", () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+  afterAll(() => server.close());
+  afterEach(() => {
+    server.resetHandlers();
+    endSessionMock();
+  });
+
+  describe("Loader: ", () => {
+    const testParams = {
+      rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+    };
+
+    test("Skal redirecte etter laging av ny korrigeringsperiode", async () => {
+      const korrigeringsPeriode = {
+        ...rapporteringsperioderResponse[0],
+        id: rapporteringsperioderResponse[0].id + 1,
+      };
+      server.use(
+        rest.post(
+          `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/${testParams.rapporteringsperiodeId}/korrigering`,
+          (_, res, ctx) => {
+            return res.once(ctx.json(korrigeringsPeriode));
+          }
+        )
+      );
+
+      mockSession();
+
+      const response = await loader({
+        request: new Request("http://localhost:3000"),
+        params: testParams,
+        context: {},
+      });
+
+      expect(response).toEqual(
+        redirect(`/rapportering/korriger/${korrigeringsPeriode.id}/fyll-ut`)
+      );
+    });
+
+    test("Skal feile hvis kallet til den bestemte rapporteringsperiode feiler", async () => {
+      server.use(
+        rest.post(
+          `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/${testParams.rapporteringsperiodeId}/korrigering`,
+          (_, res, ctx) => {
+            return res.once(
+              ctx.status(500),
+              ctx.json({
+                errorMessage: `Server Error`,
+              })
+            );
+          }
+        )
+      );
+
+      mockSession();
+
+      const response = await catchErrorResponse(() =>
+        loader({
+          request: new Request("http://localhost:3000"),
+          params: testParams,
+          context: {},
+        })
+      );
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/rapportering.periode.$rapporteringsperiodeId.send-inn.api.test.ts
+++ b/tests/routes/rapportering.periode.$rapporteringsperiodeId.send-inn.api.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { redirect } from "@remix-run/node";
+import { rest } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { action } from "~/routes/rapportering.periode.$rapporteringsperiodeId.send-inn";
+import { rapporteringsperioderResponse } from "../../mocks/api-routes/rapporteringsperioderResponse";
+import { server } from "../../mocks/server";
+import { endSessionMock, mockSession } from "../helpers/auth-helper";
+import { catchErrorResponse } from "../helpers/response-helper";
+
+describe("Send inn rapporteringsperiode", () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+  afterAll(() => server.close());
+  afterEach(() => {
+    server.resetHandlers();
+    endSessionMock();
+  });
+
+  describe("Action", () => {
+    describe("Send inn periode", () => {
+      const testBody = {};
+      const testParams = {
+        ident: "1234",
+        rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+      };
+
+      test("burde feile hvis bruker ikke er autentisert", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        const response = await catchErrorResponse(() =>
+          action({
+            request,
+            params: testParams,
+            context: {},
+          })
+        );
+
+        expect(response.status).toBe(500);
+      });
+
+      test("burde kunne godkjenne og redirecte til riktig side", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response).toEqual(
+          redirect(`/rapportering/periode/${rapporteringsperioderResponse[0].id}/bekreftelse`)
+        );
+      });
+
+      test("burde feile hvis backend feiler", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        server.use(
+          rest.post(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperioder/${rapporteringsperioderResponse[0].id}/godkjenn`,
+            (req, res, ctx) => {
+              return res.once(
+                ctx.status(500),
+                ctx.json({
+                  errorMessage: `Server Error`,
+                })
+              );
+            }
+          )
+        );
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        const data = await response.json();
+        expect(response.status).toBe(200);
+        expect(data.error).toBe("Det har skjedd noe feil med innsendingen din, prøv igjen.");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Legger på en default return på action når vi switcher på hva vi vil gjøre. På den måten har vi en default håndtering hvis det ikke sendes med riktig parametre, som også gir oss samme type på alle responser vi får tilbake. Da slipper vi å skrive `response?.status`.