### PR TITLE
Fjerner +1 på accumulator når timer ikke finnes

### DIFF
--- a/app/components/kalender/Uke.tsx
+++ b/app/components/kalender/Uke.tsx
@@ -23,7 +23,7 @@ export function Uke(props: IProps) {
         if (current.timer) {
           return accumulator + (periodeSomTimer(current.timer) ?? 0);
         }
-        return accumulator + 1;
+        return accumulator;
       }, 0);
 
       return `${timer.toString().replace(/\./g, ",")}${lang ? " timer" : "t"}`;


### PR DESCRIPTION
Fikser følgende feil: ![image](https://github.com/user-attachments/assets/5c03a19c-509b-4609-aa1d-6f92eea42458)

Feilen oppstod når arbeid og utdanning kombineres på samme dag.