### PR TITLE
Håndter 400-feilen som skjer ved innsending

### DIFF
--- a/app/models/logger.server.ts
+++ b/app/models/logger.server.ts
@@ -43,3 +43,20 @@ async function getHttpProblem(response: Response): Promise<IHttpProblem | null> 
     return null;
   }
 }
+
+export async function logg({
+  type,
+  message,
+  correlationId = null,
+  body,
+}: {
+  type: "error" | "warn" | "info" | "debug";
+  message: string;
+  correlationId: string | null;
+  body: unknown;
+}) {
+  sikkerLogger[type](`${message}, body: ${JSON.stringify(body)}`, {
+    x_correlationId: correlationId,
+  });
+  logger[type](`${message}. Se sikker logg for data.`, { x_correlationId: correlationId });
+}

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -98,7 +98,7 @@ export async function hentPeriode(
   request: Request,
   periodeId: string,
   hentOriginal: boolean = true
-): Promise<{ periode: IRapporteringsperiode }> {
+): Promise<{ periode: IRapporteringsperiode; response: Response }> {
   const url = `${DP_RAPPORTERING_URL}/rapporteringsperiode/${periodeId}`;
 
   // TODO: Legg til x_corralationId som header
@@ -122,7 +122,7 @@ export async function hentPeriode(
   const periode: IRapporteringsperiode = await response.json();
 
   // Forberedelse til å sende ved response, slik at kallende funksjon kan hente ut headers og x_corralationId
-  return { periode };
+  return { periode, response };
 }
 
 export async function hentInnsendtePerioder(request: Request): Promise<IRapporteringsperiode[]> {

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -98,9 +98,10 @@ export async function hentPeriode(
   request: Request,
   periodeId: string,
   hentOriginal: boolean = true
-): Promise<IRapporteringsperiode> {
+): Promise<{ periode: IRapporteringsperiode }> {
   const url = `${DP_RAPPORTERING_URL}/rapporteringsperiode/${periodeId}`;
 
+  // TODO: Legg til x_corralationId som header
   const response = await fetch(url, {
     method: "GET",
     headers: await getHeaders(request, {
@@ -120,7 +121,8 @@ export async function hentPeriode(
 
   const periode: IRapporteringsperiode = await response.json();
 
-  return periode;
+  // Forberedelse til å sende ved response, slik at kallende funksjon kan hente ut headers og x_corralationId
+  return { periode };
 }
 
 export async function hentInnsendtePerioder(request: Request): Promise<IRapporteringsperiode[]> {

--- a/app/routes/periode.$rapporteringsperiodeId.endring.fyll-ut.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.endring.fyll-ut.tsx
@@ -50,8 +50,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   invariant(params.rapporteringsperiodeId, "rapportering-feilmelding-periode-id-mangler-i-url");
 
   const periodeId = params.rapporteringsperiodeId;
-  const periode = await hentPeriode(request, periodeId, false);
-  const originalPeriode = await hentPeriode(request, periode.originalId as string, true);
+  const { periode } = await hentPeriode(request, periodeId, false);
+  const { periode: originalPeriode } = await hentPeriode(
+    request,
+    periode.originalId as string,
+    true
+  );
 
   return json({ periode, originalPeriode });
 }

--- a/app/routes/periode.$rapporteringsperiodeId.endring.send-inn.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.endring.send-inn.tsx
@@ -13,6 +13,7 @@ import {
 } from "@remix-run/react";
 import { useState } from "react";
 import invariant from "tiny-invariant";
+import { logErrorResponse, logg } from "~/models/logger.server";
 import {
   hentPeriode,
   hentRapporteringsperioder,
@@ -43,11 +44,25 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const periodeId = params.rapporteringsperiodeId;
 
   try {
-    const periode = await hentPeriode(request, periodeId, false);
+    const { periode } = await hentPeriode(request, periodeId, false);
 
     if (!periode.kanSendes && periode.status === IRapporteringsperiodeStatus.Innsendt) {
-      redirect(`/periode/${periodeId}/endring/bekreftelse`);
+      logg({
+        type: "warn",
+        message: `Feil i innsending av endring: endringen er allerede innsendt, ID: ${periodeId}`,
+        correlationId: null,
+        body: periode,
+      });
+
+      return redirect(`/periode/${periodeId}/endring/bekreftelse`);
     } else if (!periode.kanSendes) {
+      logg({
+        type: "error",
+        message: `Feil i innsending av endring: endringen kan ikke sendes inn, ID: ${periodeId}`,
+        correlationId: null,
+        body: periode,
+      });
+
       return json({ error: "rapportering-feilmelding-kan-ikke-sendes" }, { status: 400 });
     }
 
@@ -55,18 +70,32 @@ export async function action({ request, params }: ActionFunctionArgs) {
     const { id } = response;
     return redirect(`/periode/${id}/endring/bekreftelse`);
   } catch (error: unknown) {
-    // TODO: Her ønsker vi å vise en modal, ikke en ny side
-    // TODO: Feilen er en network error
-    if (error instanceof Response) {
-      return json(
-        {
-          error: "rapportering-feilmelding-feil-ved-innsending",
-        },
-        {
-          status: 500,
-        }
-      );
+    if (error instanceof Error) {
+      logg({
+        type: "error",
+        message: `Feil i innsending av endring: ${error.message}, ID: ${periodeId}`,
+        correlationId: null,
+        body: null,
+      });
+    } else if (error instanceof Response) {
+      logErrorResponse(error, `Klarte ikke å sende inn endring, ID: ${periodeId}`);
+    } else {
+      logg({
+        type: "error",
+        message: `Ukjent feil i innsending av endring, ID: ${periodeId}`,
+        correlationId: null,
+        body: error,
+      });
     }
+
+    return json(
+      {
+        error: "rapportering-feilmelding-feil-ved-innsending",
+      },
+      {
+        status: 500,
+      }
+    );
   }
 }
 

--- a/app/routes/periode.$rapporteringsperiodeId.endring.send-inn.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.endring.send-inn.tsx
@@ -21,6 +21,7 @@ import {
 import { formaterPeriodeDato, formaterPeriodeTilUkenummer } from "~/utils/dato.utils";
 import { useAddHtml } from "~/utils/journalforing.utils";
 import { kanSendes } from "~/utils/periode.utils";
+import { IRapporteringsperiodeStatus } from "~/utils/types";
 import { useIsSubmitting } from "~/utils/useIsSubmitting";
 import { useLocale } from "~/hooks/useLocale";
 import { useSanity } from "~/hooks/useSanity";
@@ -43,6 +44,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   try {
     const periode = await hentPeriode(request, periodeId, false);
+
+    if (!periode.kanSendes && periode.status === IRapporteringsperiodeStatus.Innsendt) {
+      redirect(`/periode/${periodeId}/endring/bekreftelse`);
+    } else if (!periode.kanSendes) {
+      return json({ error: "rapportering-feilmelding-kan-ikke-sendes" }, { status: 400 });
+    }
+
     const response = await sendInnPeriode(request, periode);
     const { id } = response;
     return redirect(`/periode/${id}/endring/bekreftelse`);

--- a/app/routes/periode.$rapporteringsperiodeId.send-inn.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.send-inn.tsx
@@ -21,6 +21,7 @@ import {
 import { formaterPeriodeDato, formaterPeriodeTilUkenummer } from "~/utils/dato.utils";
 import { useAddHtml } from "~/utils/journalforing.utils";
 import { kanSendes } from "~/utils/periode.utils";
+import { IRapporteringsperiodeStatus } from "~/utils/types";
 import { useIsSubmitting } from "~/utils/useIsSubmitting";
 import { useAmplitude } from "~/hooks/useAmplitude";
 import { useLocale } from "~/hooks/useLocale";
@@ -47,6 +48,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   try {
     const periode = await hentPeriode(request, periodeId, false);
+
+    if (!periode.kanSendes && periode.status === IRapporteringsperiodeStatus.Innsendt) {
+      redirect(`/periode/${periodeId}/bekreftelse`);
+    } else if (!periode.kanSendes) {
+      return json({ error: "rapportering-feilmelding-kan-ikke-sendes" }, { status: 400 });
+    }
+
     const response = await sendInnPeriode(request, periode);
     const { id } = response;
     return redirect(`/periode/${id}/bekreftelse`);

--- a/app/routes/periode.$rapporteringsperiodeId.send-inn.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.send-inn.tsx
@@ -13,6 +13,7 @@ import {
 } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import invariant from "tiny-invariant";
+import { logErrorResponse, logg } from "~/models/logger.server";
 import {
   hentPeriode,
   hentRapporteringsperioder,
@@ -47,11 +48,25 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const periodeId = params.rapporteringsperiodeId;
 
   try {
-    const periode = await hentPeriode(request, periodeId, false);
+    const { periode } = await hentPeriode(request, periodeId, false);
 
     if (!periode.kanSendes && periode.status === IRapporteringsperiodeStatus.Innsendt) {
-      redirect(`/periode/${periodeId}/bekreftelse`);
+      logg({
+        type: "warn",
+        message: `Feil i innsending av periode: perioden er allerede innsendt, ID: ${periodeId}`,
+        correlationId: null,
+        body: periode,
+      });
+
+      return redirect(`/periode/${periodeId}/bekreftelse`);
     } else if (!periode.kanSendes) {
+      logg({
+        type: "error",
+        message: `Feil i innsending av periode: perioden kan ikke sendes inn, ID: ${periodeId}`,
+        correlationId: null,
+        body: periode,
+      });
+
       return json({ error: "rapportering-feilmelding-kan-ikke-sendes" }, { status: 400 });
     }
 
@@ -59,19 +74,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     const { id } = response;
     return redirect(`/periode/${id}/bekreftelse`);
   } catch (error: unknown) {
-    // TODO: Her ønsker vi å vise en modal, ikke en ny side
-    // TODO: Feilen er en network error
     if (error instanceof Error) {
-      return json(
-        {
-          error: "rapportering-feilmelding-feil-ved-innsending",
-        },
-        {
-          status: 500,
-        }
-      );
+      logg({
+        type: "error",
+        message: `Feil i innsending av periode: ${error.message}, ID: ${periodeId}`,
+        correlationId: null,
+        body: null,
+      });
+    } else if (error instanceof Response) {
+      logErrorResponse(error, `Klarte ikke å sende inn periode, ID: ${periodeId}`);
+    } else {
+      logg({
+        type: "error",
+        message: `Ukjent feil i innsending av periode, ID: ${periodeId}`,
+        correlationId: null,
+        body: error,
+      });
     }
-
     return json(
       {
         error: "rapportering-feilmelding-feil-ved-innsending",

--- a/app/routes/periode.$rapporteringsperiodeId.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.tsx
@@ -14,7 +14,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   invariant(params.rapporteringsperiodeId, "rapportering-feilmelding-periode-id-mangler-i-url");
 
   const periodeId = params.rapporteringsperiodeId;
-  const periode = await hentPeriode(request, periodeId, false);
+  const { periode } = await hentPeriode(request, periodeId, false);
 
   return json({ periode });
 }

--- a/app/utils/fetch.utils.ts
+++ b/app/utils/fetch.utils.ts
@@ -4,6 +4,10 @@ import { uuidv7 } from "uuidv7";
 import { getSessionId } from "~/../mocks/session";
 import { IHttpProblem } from "~/utils/types";
 
+export function getCorralationId(headers: Headers) {
+  return headers.get("X-Request-ID") ?? "";
+}
+
 function generateCorralationId() {
   // https://github.com/navikt/dp-rapportering-frontend/pull/242#pullrequestreview-2403834306
   // korralasjon_id i dp-rappoortering kan være på maks 54 tegn

--- a/app/utils/fetch.utils.ts
+++ b/app/utils/fetch.utils.ts
@@ -1,15 +1,25 @@
 import { getRapporteringOboToken } from "./auth.utils.server";
 import { isLocalOrDemo } from "./env.utils";
+import { uuidv7 } from "uuidv7";
 import { getSessionId } from "~/../mocks/session";
 import { IHttpProblem } from "~/utils/types";
 
+function generateCorralationId() {
+  // https://github.com/navikt/dp-rapportering-frontend/pull/242#pullrequestreview-2403834306
+  // korralasjon_id i dp-rappoortering kan være på maks 54 tegn
+  return `dp-rapp-${uuidv7()}`.substring(0, 54);
+}
+
 export async function getHeaders(request: Request, customHeaders = {}) {
   const onBehalfOfToken = await getRapporteringOboToken(request);
+
+  const corralationId = request.headers.get("X-Request-ID") ?? generateCorralationId();
 
   const headers = {
     "Content-Type": "application/json",
     Accept: "application/json",
     Authorization: `Bearer ${onBehalfOfToken}`,
+    "X-Request-ID": corralationId,
     ...customHeaders,
   };
 

--- a/app/utils/fetch.utils.ts
+++ b/app/utils/fetch.utils.ts
@@ -17,13 +17,11 @@ function generateCorralationId() {
 export async function getHeaders(request: Request, customHeaders = {}) {
   const onBehalfOfToken = await getRapporteringOboToken(request);
 
-  const corralationId = request.headers.get("X-Request-ID") ?? generateCorralationId();
-
   const headers = {
     "Content-Type": "application/json",
     Accept: "application/json",
     Authorization: `Bearer ${onBehalfOfToken}`,
-    "X-Request-ID": corralationId,
+    "X-Request-ID": generateCorralationId(),
     ...customHeaders,
   };
 

--- a/tests/routes/periode.rapporteringsperiodeId.endring.send-inn.api.test.ts
+++ b/tests/routes/periode.rapporteringsperiodeId.endring.send-inn.api.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { redirect } from "@remix-run/node";
+import { HttpResponse, http } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { action } from "~/routes/periode.$rapporteringsperiodeId.endring.send-inn";
+import { IRapporteringsperiodeStatus } from "~/utils/types";
+import { rapporteringsperioderResponse } from "../../mocks/responses/rapporteringsperioderResponse";
+import { server } from "../../mocks/server";
+import { endSessionMock, mockSession } from "../helpers/auth-helper";
+
+const rapporteringsperiodeResponse = rapporteringsperioderResponse[0];
+
+describe("Send inn rapporteringsperiode", () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+  afterAll(() => server.close());
+  afterEach(() => {
+    server.resetHandlers();
+    endSessionMock();
+  });
+
+  describe("Action", () => {
+    describe("Send inn periode", () => {
+      const testBody = {
+        _html: "<div />",
+      };
+      const testParams = {
+        ident: "1234",
+        rapporteringsperiodeId: rapporteringsperioderResponse[0].id,
+      };
+
+      test("burde redirecte til bekreftelsesside hvis rapporteringen allerede er sendt inn", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        server.use(
+          http.get(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperiode/:rapporteringsperiodeId`,
+            () => {
+              return HttpResponse.json(
+                { id: "1", kanSendes: false, status: IRapporteringsperiodeStatus.Innsendt },
+                { status: 200 }
+              );
+            }
+          )
+        );
+
+        server.use(
+          http.post(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperiode`,
+            async ({ request }) => {
+              const sentRequest = await request.text();
+              expect(sentRequest).toBe(
+                `{"id":"1","kanSendes":true,"status":${IRapporteringsperiodeStatus.TilUtfylling},"html":"<div />"}`
+              );
+
+              return HttpResponse.json(null, {
+                status: 400,
+              });
+            },
+            { once: true }
+          )
+        );
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        expect(response).toEqual(
+          redirect(`/periode/${rapporteringsperiodeResponse.id}/endring/bekreftelse`)
+        );
+      });
+
+      test("burde vise feilmelding hvis perioden ikke kan sendes inn", async () => {
+        const body = new URLSearchParams(testBody);
+
+        const request = new Request("http://localhost:3000", {
+          method: "POST",
+          body,
+        });
+
+        server.use(
+          http.get(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperiode/:rapporteringsperiodeId`,
+            () => {
+              return HttpResponse.json({ id: "1", kanSendes: false }, { status: 200 });
+            }
+          )
+        );
+
+        server.use(
+          http.post(
+            `${process.env.DP_RAPPORTERING_URL}/rapporteringsperiode`,
+            async ({ request }) => {
+              const sentRequest = await request.text();
+              expect(sentRequest).toBe(
+                `{"id":"1","kanSendes":true,"status":${IRapporteringsperiodeStatus.TilUtfylling},"html":"<div />"}`
+              );
+
+              return HttpResponse.json(null, {
+                status: 400,
+              });
+            },
+            { once: true }
+          )
+        );
+
+        mockSession();
+
+        const response = await action({
+          request,
+          params: testParams,
+          context: {},
+        });
+
+        const data = await response.json();
+        expect(response.status).toBe(400);
+
+        expect(data.error).toBe("rapportering-feilmelding-kan-ikke-sendes");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Brukere opplever ikke at meldekortet blir sendt inn, og sender det inn på nytt, men da er kanSendes satt til false og status til "innsendt" i dp-rapportering. Hvis det er tilfellet blir brukeren tatt til bekreftelsessiden. Hvis kanSendes er satt til false ellers er vi i en feilsituasjon, og brukeren må kontakte Nav.

PR-en legger også til logging for disse situasjonene. Det er ønskelig å legge til corralationId på kallene til dp-rapportering, og det er det den som gjør kallet (dp-rapportering-frontend) som skal gjøres. Det gjenstår litt tenkearbeid før dette kan gjøres.

Vi håndterer kall i api-metodene, derfor må vi endre returverdien til å inneholde både dataen (periode i dette tilfellet) og responsen, slik at corralationId kan hentes ut til logging, og potensielt også URL. Dette er work to be done.

Feilmeldingen er lagt til i Sanity

