### PR TITLE
Hent original ved endre-endepunktet

### DIFF
--- a/app/routes/periode.$rapporteringsperiodeId.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.tsx
@@ -14,7 +14,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   invariant(params.rapporteringsperiodeId, "rapportering-feilmelding-periode-id-mangler-i-url");
 
   const periodeId = params.rapporteringsperiodeId;
-  const periode = await hentPeriode(request, periodeId, false);
+
+  const skalHenteOriginal = ["endre"];
+  const hentOriginal = skalHenteOriginal.some((url) => request.url.includes(url));
+
+  const periode = await hentPeriode(request, periodeId, hentOriginal);
 
   return json({ periode });
 }


### PR DESCRIPTION
Når bruker trykker på "endre meldekort" tas bruker først til periode/ID/endre, og da blir loaderen i periode/ID kalt med hentOriginal: false. Det gir en 404-feil, fordi meldekortet ikke finnes i dp-rapportering enda. 

Ved å sjekke om brukeren kaller på endre-endepunktet kan vi i stedet for hente den originale meldekortet fra Arena. 

Dette er egentlig unødvendig, fordi vi ikke trenger det originale endepunktet, og fører til mer lasting av data. ID-en i URL-en blir senere byttet ut med ID-en til det korrigerte meldekortet, så det burde ikke føre til at bruker får feil meldekort.