### PR TITLE
juster router historikk ved tilbakeknapp i fyll ut skjema

### DIFF
--- a/app/routes/periode.$rapporteringsperiodeId.endring.fyll-ut.tsx
+++ b/app/routes/periode.$rapporteringsperiodeId.endring.fyll-ut.tsx
@@ -168,6 +168,7 @@ export default function RapporteringsPeriodeFyllUtSide() {
           className={navigasjonStyles.knapp}
           icon={<ArrowLeftIcon aria-hidden />}
           iconPosition="left"
+          onClick={() => navigate(-1)}
         >
           {getAppText("rapportering-knapp-tilbake")}
         </RemixLink>


### PR DESCRIPTION
Når bruker legger velger "tilbake" i aktivitetsskjemaet så skal router historikken fjerne aktivitetsskjemaet slik at neste knappen og broswer tilbakeknappen matcher