### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     steps:
       - uses: actions/checkout@v4
       - name: Cache node_modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
       - name: Cache node_modules


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/dp-rapportering-frontend/security/code-scanning/7](https://github.com/navikt/dp-rapportering-frontend/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the `test` job. This block will explicitly define the minimal permissions required for the job to function. Based on the job's steps, it only needs `contents: read` to access the repository contents and `packages: read` to interact with the npm registry. No write permissions are necessary.

The `permissions` block will be added immediately after the `runs-on` key in the `test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
