### PR TITLE
ta hensyn til arena meldekort for utfylling med spm 5

### DIFF
--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -5,6 +5,7 @@ import { getHeaders } from "~/utils/fetch.utils";
 import {
   IRapporteringsperiodeStatus,
   KortType,
+  OPPRETTET_AV,
   Rapporteringstype,
   TOpprettetAv,
 } from "~/utils/types";
@@ -170,7 +171,8 @@ export async function sendInnPeriode(
     ...rapporteringsperiode,
     html: html.toString().trim(),
     registrertArbeidssoker:
-      rapporteringsperiode.type === KortType.ETTERREGISTRERT
+      rapporteringsperiode.type === KortType.ETTERREGISTRERT ||
+      rapporteringsperiode.opprettetAv === OPPRETTET_AV.Arena
         ? true
         : rapporteringsperiode.registrertArbeidssoker,
   };

--- a/app/utils/periode.utils.test.ts
+++ b/app/utils/periode.utils.test.ts
@@ -16,13 +16,13 @@ describe("skalHaArbeidssokerSporsmal", () => {
     expect(skalHaArbeidssokerSporsmal(periode)).toBe(true);
   });
 
-  test("skal returnere false når perioden er opprettet av Arena", () => {
+  test("skal returnere true når perioden er opprettet av Arena og ikke er etterregistrert", () => {
     const periode = lagRapporteringsperiode({
       opprettetAv: OPPRETTET_AV.Arena,
       type: KortType.ORDINAERT,
     });
 
-    expect(skalHaArbeidssokerSporsmal(periode)).toBe(false);
+    expect(skalHaArbeidssokerSporsmal(periode)).toBe(true);
   });
 
   test("skal returnere false når perioden er etterregistrert", () => {
@@ -34,21 +34,21 @@ describe("skalHaArbeidssokerSporsmal", () => {
     expect(skalHaArbeidssokerSporsmal(periode)).toBe(false);
   });
 
-  test("skal returnere false når opprettetAv er null", () => {
+  test("skal returnere true når opprettetAv er null og ikke er etterregistrert", () => {
     const periode = lagRapporteringsperiode({
       opprettetAv: null,
       type: KortType.ORDINAERT,
     });
 
-    expect(skalHaArbeidssokerSporsmal(periode)).toBe(false);
+    expect(skalHaArbeidssokerSporsmal(periode)).toBe(true);
   });
 
-  test("skal returnere false når perioden er opprettet av Arena selv om den ikke er etterregistrert", () => {
+  test("skal returnere true når perioden er opprettet av Arena og er korrigert", () => {
     const periode = lagRapporteringsperiode({
       opprettetAv: OPPRETTET_AV.Arena,
       type: KortType.KORRIGERT,
     });
 
-    expect(skalHaArbeidssokerSporsmal(periode)).toBe(false);
+    expect(skalHaArbeidssokerSporsmal(periode)).toBe(true);
   });
 });

--- a/app/utils/periode.utils.tsx
+++ b/app/utils/periode.utils.tsx
@@ -11,7 +11,7 @@ import {
 import { AktivitetType, IAktivitet } from "./aktivitettype.utils";
 import { formaterPeriodeDato, formaterPeriodeTilUkenummer } from "./dato.utils";
 import { DecoratorLocale } from "./dekoratoren.utils";
-import { IRapporteringsperiodeStatus, KortType, OPPRETTET_AV } from "./types";
+import { IRapporteringsperiodeStatus, KortType } from "./types";
 
 export function periodeSomTimer(periode?: string): number | undefined {
   if (!periode) return undefined;
@@ -189,10 +189,9 @@ export function erPeriodeneLike(
 }
 
 export function skalHaArbeidssokerSporsmal(periode: IRapporteringsperiode): boolean {
-  const erDagpenger = periode.opprettetAv === OPPRETTET_AV.Dagpenger;
   const erIkkeEtterregistrert = periode.type !== KortType.ETTERREGISTRERT;
 
-  return erDagpenger && erIkkeEtterregistrert;
+  return erIkkeEtterregistrert;
 }
 
 interface IPeriodeDate {


### PR DESCRIPTION
## Beskrivelse
-Arena meldekort fikk ikke opp spørsmål 5 i utfyllingen og sendte dermed null til backend.

Lenke til oppgave/issue: https://nav-it.slack.com/archives/C073D509YNQ/p1778058237534289
