### PR TITLE
Samle opp minor- og patch-oppdateringer i samme PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,15 +9,6 @@ updates:
       timezone: "Europe/Oslo"
     cooldown:
       default-days: 7
-  # Maintain dependencies for gradle
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:05"
-      timezone: "Europe/Oslo"
-    cooldown:
-      default-days: 7
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
     directory: "/"
@@ -34,5 +25,10 @@ updates:
       interval: "daily"
       time: "10:05"
       timezone: "Europe/Oslo"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Beskrivelse
Det genereres fra tid til annen veldig mange PRer per frontend-app, og gjerne patch-oppdateringer fra samme bibliotek, feks Aksel. Fikses med Depandabot-konfigurasjon,

Lenke til oppgave/issue: https://trello.com/c/HRzIZVS4/501-grupper-minor-og-patch-oppdateringer-i-%C3%A9n-dependabot-pr
